### PR TITLE
Feature enemy logic change

### DIFF
--- a/Assets/PolygonNatureBiomes/URP_ExtractMe_Nature_Biomes.unitypackage.meta
+++ b/Assets/PolygonNatureBiomes/URP_ExtractMe_Nature_Biomes.unitypackage.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 92f9cd028443b7645a5012a799b57dab
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Enemy/TempBullet.prefab
+++ b/Assets/Prefabs/Enemy/TempBullet.prefab
@@ -64,7 +64,7 @@ MeshRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  - {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0

--- a/Assets/Scenes/Enemy/TestEnemyAnimScene.unity
+++ b/Assets/Scenes/Enemy/TestEnemyAnimScene.unity
@@ -391,7 +391,7 @@ MeshRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  - {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0

--- a/Assets/Scripts/Enemy/EnemyController.cs
+++ b/Assets/Scripts/Enemy/EnemyController.cs
@@ -45,6 +45,7 @@ public abstract class EnemyController : MonoBehaviour
 
     [Header("AttackCheck")]
     [HideInInspector] public EnemyFieldOfView _enemyFieldOfView;
+    public bool _isCurrentAttackCor;
 
 
     protected virtual void Awake()
@@ -99,5 +100,7 @@ public abstract class EnemyController : MonoBehaviour
     {
         HP -= damage;
     }
+
+    protected abstract void Attack();
 }
 

--- a/Assets/Scripts/Enemy/EnemyController.cs
+++ b/Assets/Scripts/Enemy/EnemyController.cs
@@ -100,7 +100,5 @@ public abstract class EnemyController : MonoBehaviour
     {
         HP -= damage;
     }
-
-    protected abstract void Attack();
 }
 

--- a/Assets/Scripts/Enemy/State/EnemyAttackState.cs
+++ b/Assets/Scripts/Enemy/State/EnemyAttackState.cs
@@ -62,7 +62,8 @@ public class EnemyAttackState : State<EnemyController>
             switch (_enemyController.EnemyType)
             {
                 case EnemyType.range:
-                    _enemyController.StartCoroutine(AttackRangeCor());
+                    EnemyController_Range enemy = _enemyController.GetComponent<EnemyController_Range>();
+                    _enemyController.StartCoroutine(enemy.AttackRangeCor());
                     break;
                 case EnemyType.melee:
                      _enemyController.StartCoroutine(AttackMeleeCor());
@@ -73,54 +74,6 @@ public class EnemyAttackState : State<EnemyController>
         }
     }
 
-    /// <summary>
-    /// 원거리 공격
-    /// </summary>
-    /// <returns></returns>
-    IEnumerator AttackRangeCor()
-    {
-
-        // 잘못 인식된 경우 나가기
-        if (Vector3.Distance(_enemyController.transform.position, _player.transform.position) > _enemyController.AttackRange + _agent.stoppingDistance)
-        {
-            _isCurrentAttackCor = false;
-            yield break;
-        }
-
-        _isCurrentAttackCor = true;
-
-        _enemyController._agent.isStopped = true;
-
-        Vector3 dir = _player.transform.position - _enemyController.transform.position;
-        float timer = 0;
-        while (timer <= 0.5f)       // 약간의 delay. temp 값.
-        {
-            timer += Time.deltaTime;
-
-            _enemyController.transform.rotation = Quaternion.Lerp(_enemyController.transform.rotation, Quaternion.LookRotation(dir), Time.deltaTime * 2);
-
-            yield return new WaitForEndOfFrame();
-
-        }
-
-        _enemyController._anim.SetTrigger("Attack");
-
-        EnemyController_Range enemy = _enemyController.GetComponent<EnemyController_Range>();
-
-        //공격
-        GameObject bullet = enemy.InsBullet();
-        bullet.transform.position = enemy._attackTransform.position;
-        bullet.transform.rotation = Quaternion.LookRotation(dir).normalized;
-
-        // damage 할당
-        EnemyBullet eb = bullet.GetComponent<EnemyBullet>();
-        eb._damage = (int)_enemyController.Damage;
-
-        yield return new WaitForSeconds(_enemyController.AttackSpeed);
-        _enemyController._agent.isStopped = false;
-        _isCurrentAttackCor = false;
-
-    }
 
     /// <summary>
     /// 근거리 공격

--- a/Assets/Scripts/Enemy/State/EnemyAttackState.cs
+++ b/Assets/Scripts/Enemy/State/EnemyAttackState.cs
@@ -14,8 +14,6 @@ public class EnemyAttackState : State<EnemyController>
     private NavMeshAgent _agent;
     private EnemyFieldOfView _fov;
 
-    private bool _isCurrentAttackCor;
-
     private float _agentStopDistance;
 
     public override void OnEnter()
@@ -41,7 +39,7 @@ public class EnemyAttackState : State<EnemyController>
         {
             _agent.SetDestination(_player.transform.position);
         }
-        else if (!_enemyController._enemyFieldOfView._isVisiblePlayer && _isCurrentAttackCor == false)
+        else if (!_enemyController._enemyFieldOfView._isVisiblePlayer && _enemyController._isCurrentAttackCor == false)
         {
             _enemyController._anim.SetBool("WalkToPlayer", false);
             _enemyController.ChangeState<EnemyIdleState>();
@@ -59,7 +57,7 @@ public class EnemyAttackState : State<EnemyController>
 
 
 
-        if (_agent.remainingDistance <= _agent.stoppingDistance && _isCurrentAttackCor == false )
+        if (_agent.remainingDistance <= _agent.stoppingDistance && _enemyController._isCurrentAttackCor == false )
         {
             switch (_enemyController.EnemyType)
             {

--- a/Assets/Scripts/Enemy/State/EnemyAttackState.cs
+++ b/Assets/Scripts/Enemy/State/EnemyAttackState.cs
@@ -62,11 +62,12 @@ public class EnemyAttackState : State<EnemyController>
             switch (_enemyController.EnemyType)
             {
                 case EnemyType.range:
-                    EnemyController_Range enemy = _enemyController.GetComponent<EnemyController_Range>();
-                    _enemyController.StartCoroutine(enemy.AttackRangeCor());
+                    EnemyController_Range enemyR = _enemyController.GetComponent<EnemyController_Range>();
+                    _enemyController.StartCoroutine(enemyR.AttackRangeCor());
                     break;
                 case EnemyType.melee:
-                     _enemyController.StartCoroutine(AttackMeleeCor());
+                    EnemyController_Melee enemyM = _enemyController.GetComponent<EnemyController_Melee>();
+                     _enemyController.StartCoroutine(enemyM.AttackMeleeCor());
                     break;
                 default:
                     break;
@@ -75,52 +76,7 @@ public class EnemyAttackState : State<EnemyController>
     }
 
 
-    /// <summary>
-    /// 근거리 공격
-    /// </summary>
-    /// <returns></returns>
-    IEnumerator AttackMeleeCor()
-    {
-        _isCurrentAttackCor = true;
 
-        // 잘못 인식된 경우 나가기
-        if(Vector3.Distance(_enemyController.transform.position, _player.transform.position) > _enemyController.AttackRange + _agent.stoppingDistance)
-        {
-            _isCurrentAttackCor = false;
-            yield break;
-        }
-
-        _enemyController._agent.isStopped = true;
-
-        float timer = 0;
-        while (timer <= 0.2f)       // 약간의 delay. temp 값.
-        {
-            timer += Time.deltaTime;
-
-            Vector3 dir = _player.transform.position - _enemyController.transform.position;
-            _enemyController.transform.rotation = Quaternion.Lerp(_enemyController.transform.rotation, Quaternion.LookRotation(dir), Time.deltaTime * 2);
-
-            yield return new WaitForEndOfFrame();
-        
-        }
-
-        _enemyController._anim.SetTrigger("Attack");
-
-        // 실제 공격 체크
-        if (_enemyController._enemyFieldOfView._isVisiblePlayer && Vector3.Distance(_enemyController.transform.position, _player.transform.position) < _enemyController.AttackRange + _agent.stoppingDistance)
-        {
-            PlayerHit player = _player.GetComponent<PlayerHit>();     //  추후 싱글톤으로 찾는다면 로직 수정
-            player.Hit(_enemyController.Damage);
-        }
-
-
-        yield return new WaitForSeconds(_enemyController.AttackSpeed);
-
-        _enemyController._agent.isStopped = false;
-
-        _isCurrentAttackCor = false;
-
-    }
 
     public override void OnExit()
     {

--- a/Assets/Scripts/Enemy/Type/EnemyController_Melee.cs
+++ b/Assets/Scripts/Enemy/Type/EnemyController_Melee.cs
@@ -5,7 +5,7 @@ using static UnityEditor.Experimental.GraphView.GraphView;
 
 public class EnemyController_Melee : EnemyController
 {
-    PlayerManager _player = PlayerManager.Instance;
+    PlayerManager _player => PlayerManager.Instance;
 
     protected override void Start()
     {

--- a/Assets/Scripts/Enemy/Type/EnemyController_Melee.cs
+++ b/Assets/Scripts/Enemy/Type/EnemyController_Melee.cs
@@ -1,9 +1,12 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using static UnityEditor.Experimental.GraphView.GraphView;
 
 public class EnemyController_Melee : EnemyController
 {
+    PlayerManager _player = PlayerManager.Instance;
+
     protected override void Start()
     {
         base.Start();
@@ -11,5 +14,52 @@ public class EnemyController_Melee : EnemyController
         _stateMachine.AddState(new EnemyDieState());
         _stateMachine.AddState(new EnemyMoveState());
         _stateMachine.AddState(new EnemyAttackState());
+    }
+
+    /// <summary>
+    /// 근거리 공격
+    /// </summary>
+    /// <returns></returns>
+    public IEnumerator AttackMeleeCor()
+    {
+        _isCurrentAttackCor = true;
+
+        // 잘못 인식된 경우 나가기
+        if (Vector3.Distance(transform.position, _player.transform.position) > AttackRange + _agent.stoppingDistance)
+        {
+            _isCurrentAttackCor = false;
+            yield break;
+        }
+
+        _agent.isStopped = true;
+
+        float timer = 0;
+        while (timer <= 0.2f)       // 약간의 delay. temp 값.
+        {
+            timer += Time.deltaTime;
+
+            Vector3 dir = _player.transform.position - transform.position;
+            transform.rotation = Quaternion.Lerp(transform.rotation, Quaternion.LookRotation(dir), Time.deltaTime * 2);
+
+            yield return new WaitForEndOfFrame();
+
+        }
+
+        _anim.SetTrigger("Attack");
+
+        // 실제 공격 체크
+        if (_enemyFieldOfView._isVisiblePlayer && Vector3.Distance(transform.position, _player.transform.position) < AttackRange + _agent.stoppingDistance)
+        {
+            PlayerHit player = _player.GetComponent<PlayerHit>();     //  추후 싱글톤으로 찾는다면 로직 수정
+            player.Hit(Damage);
+        }
+
+
+        yield return new WaitForSeconds(AttackSpeed);
+
+        _agent.isStopped = false;
+
+        _isCurrentAttackCor = false;
+
     }
 }

--- a/Assets/Scripts/Enemy/Type/EnemyController_Range.cs
+++ b/Assets/Scripts/Enemy/Type/EnemyController_Range.cs
@@ -1,12 +1,15 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using static UnityEditor.Experimental.GraphView.GraphView;
 
 public class EnemyController_Range : EnemyController
 {
     [Header("Attack")]
     public Transform _attackTransform;
     [SerializeField] GameObject _bulletPrefab;
+
+    PlayerManager _player => PlayerManager.Instance;
 
     protected override void Start()
     {
@@ -28,5 +31,52 @@ public class EnemyController_Range : EnemyController
     public GameObject InsBullet()
     {
         return Instantiate(_bulletPrefab);
+    }
+
+
+    /// <summary>
+    /// 원거리 공격
+    /// </summary>
+    /// <returns></returns>
+    public IEnumerator AttackRangeCor()
+    {
+
+        // 잘못 인식된 경우 나가기
+        if (Vector3.Distance(transform.position, _player.transform.position) > AttackRange + _agent.stoppingDistance)
+        {
+            _isCurrentAttackCor = false;
+            yield break;
+        }
+
+        _isCurrentAttackCor = true;
+        _agent.isStopped = true;
+
+        Vector3 dir = _player.transform.position - transform.position;
+        float timer = 0;
+        while (timer <= 0.5f)       // 약간의 delay. temp 값.
+        {
+            timer += Time.deltaTime;
+
+            transform.rotation = Quaternion.Lerp(transform.rotation, Quaternion.LookRotation(dir), Time.deltaTime * 2);
+
+            yield return new WaitForEndOfFrame();
+
+        }
+
+        _anim.SetTrigger("Attack");
+
+        //공격
+        GameObject bullet = InsBullet();
+        bullet.transform.position = _attackTransform.position;
+        bullet.transform.rotation = Quaternion.LookRotation(dir).normalized;
+
+        // damage 할당
+        EnemyBullet eb = bullet.GetComponent<EnemyBullet>();
+        eb._damage = (int)Damage;
+
+        yield return new WaitForSeconds(AttackSpeed);
+        _agent.isStopped = false;
+        _isCurrentAttackCor = false;
+
     }
 }


### PR DESCRIPTION
## 개요✍️
- Enemy Attack Logic 변경 

## 작업사항🛠️
- 몬스터의 공격 호출 방식을 변경하였다.

## 변경 로직🕹️
- 기존 AttackState에서 처리하던 공격 코루틴을 각 EnemyController에 이동.
- 추후 Enemy Type이 많아지더라도 AttackState에서는 과하게 스크립트가 늘어나지 않는다. 
- 코루틴을 이동하면서 일부 변수 호출 방식 변경 (Player Singleton)


