### PR TITLE
:bug: | 공격 버그 해결

### DIFF
--- a/Assets/Scripts/Item/Weapon/GreatSword.cs
+++ b/Assets/Scripts/Item/Weapon/GreatSword.cs
@@ -47,7 +47,7 @@ public class GreatSword : Weapon
             {
                 // 적의 위치를 가져와서 플레이어와의 각도를 계산
                 Vector3 direction = hit.transform.position - origin;
-                float angle = Vector3.Angle(transform.forward, direction);
+                float angle = Vector3.Angle(_playerTransform.forward, direction);
 
                 // 감지 범위 내에 있는지, 중복이 아닌지 체크
                 if (angle < _detectionAngle * 0.5f && _detectionLists.Contains(hit) == false)


### PR DESCRIPTION
## 개요✍️
- 플레이어 공격시 각도에 상관없이 피격 처리가 되는 버그 발생

## 작업사항🛠️
- 각도 계산 로직 수정

## 변경 로직🕹️
- 각도의 중심이 되는 위치를 무기의 위치가 아닌 Player의 위치로 수정
float angle = Vector3.Angle(transform.forward, direction); -> float angle = Vector3.Angle(_playerTransform.forward, direction);