### PR TITLE
:bug: ㅣ enemy Die 여러번 호출 예외처리

### DIFF
--- a/Assets/Animations/Enemy/Melee/Enemy_Melee.controller
+++ b/Assets/Animations/Enemy/Melee/Enemy_Melee.controller
@@ -34,6 +34,7 @@ AnimatorState:
   m_CycleOffset: 0
   m_Transitions:
   - {fileID: -8882455354473855140}
+  - {fileID: -1336822117734129121}
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
@@ -215,6 +216,31 @@ AnimatorStateTransition:
   m_TransitionOffset: 0
   m_ExitTime: 0.7413793
   m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1101 &-1336822117734129121
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: Die
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 1359732323988807308}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.7413793
+  m_HasExitTime: 1
   m_HasFixedDuration: 1
   m_InterruptionSource: 0
   m_OrderedInterruption: 1

--- a/Assets/Scenes/TrainScene/MineScene.unity
+++ b/Assets/Scenes/TrainScene/MineScene.unity
@@ -197,6 +197,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 2146237598}
+  - {fileID: 520230485}
   m_Father: {fileID: 0}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -212,6 +213,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ff0646cb0cbd63c4e9945047227b49d0, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!224 &520230485 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 7467809885952191658, guid: c8aba734f70d6f84e97e959b358410ed,
+    type: 3}
+  m_PrefabInstance: {fileID: 855893873}
+  m_PrefabAsset: {fileID: 0}
 --- !u!114 &567504456 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 6401699004113738589, guid: a19a6135a5352bc4286384ebace07097,
@@ -453,6 +460,145 @@ Transform:
   m_Father: {fileID: 1956207370}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &855893873
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 234294540}
+    m_Modifications:
+    - target: {fileID: 7467809884867156779, guid: c8aba734f70d6f84e97e959b358410ed,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7467809884867156779, guid: c8aba734f70d6f84e97e959b358410ed,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7467809885161008440, guid: c8aba734f70d6f84e97e959b358410ed,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7467809885161008440, guid: c8aba734f70d6f84e97e959b358410ed,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7467809885952191658, guid: c8aba734f70d6f84e97e959b358410ed,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7467809885952191658, guid: c8aba734f70d6f84e97e959b358410ed,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7467809885952191658, guid: c8aba734f70d6f84e97e959b358410ed,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7467809885952191658, guid: c8aba734f70d6f84e97e959b358410ed,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7467809885952191658, guid: c8aba734f70d6f84e97e959b358410ed,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7467809885952191658, guid: c8aba734f70d6f84e97e959b358410ed,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7467809885952191658, guid: c8aba734f70d6f84e97e959b358410ed,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7467809885952191658, guid: c8aba734f70d6f84e97e959b358410ed,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7467809885952191658, guid: c8aba734f70d6f84e97e959b358410ed,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7467809885952191658, guid: c8aba734f70d6f84e97e959b358410ed,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7467809885952191658, guid: c8aba734f70d6f84e97e959b358410ed,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7467809885952191658, guid: c8aba734f70d6f84e97e959b358410ed,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7467809885952191658, guid: c8aba734f70d6f84e97e959b358410ed,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7467809885952191658, guid: c8aba734f70d6f84e97e959b358410ed,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7467809885952191658, guid: c8aba734f70d6f84e97e959b358410ed,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7467809885952191658, guid: c8aba734f70d6f84e97e959b358410ed,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7467809885952191658, guid: c8aba734f70d6f84e97e959b358410ed,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7467809885952191658, guid: c8aba734f70d6f84e97e959b358410ed,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7467809885952191658, guid: c8aba734f70d6f84e97e959b358410ed,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7467809885952191658, guid: c8aba734f70d6f84e97e959b358410ed,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7467809885952191658, guid: c8aba734f70d6f84e97e959b358410ed,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7467809885952191662, guid: c8aba734f70d6f84e97e959b358410ed,
+        type: 3}
+      propertyPath: m_Name
+      value: PlayerUI
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: c8aba734f70d6f84e97e959b358410ed, type: 3}
 --- !u!1001 &991109572
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -761,7 +907,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1226416279}
-  m_LocalRotation: {x: 0.29830715, y: -0.36218616, z: 0.12356287, w: 0.8743948}
+  m_LocalRotation: {x: 0.29830718, y: -0.3621862, z: 0.123562865, w: 0.8743948}
   m_LocalPosition: {x: 2.3199997, y: 8.6, z: -13.36}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
@@ -1061,17 +1207,17 @@ PrefabInstance:
     - target: {fileID: 635215942287709944, guid: a2c350fdf1c82474d95e3a9d14b65590,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.29830715
+      value: 0.29830718
       objectReference: {fileID: 0}
     - target: {fileID: 635215942287709944, guid: a2c350fdf1c82474d95e3a9d14b65590,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0.36218616
+      value: -0.3621862
       objectReference: {fileID: 0}
     - target: {fileID: 635215942287709944, guid: a2c350fdf1c82474d95e3a9d14b65590,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0.12356287
+      value: 0.123562865
       objectReference: {fileID: 0}
     - target: {fileID: 635215942287709944, guid: a2c350fdf1c82474d95e3a9d14b65590,
         type: 3}

--- a/Assets/Scripts/Enemy/EnemyController.cs
+++ b/Assets/Scripts/Enemy/EnemyController.cs
@@ -90,11 +90,6 @@ public class EnemyController : Entity
     {
         _stateMachine.Update(Time.deltaTime);
 
-        if(!_isDie && HP <= 0 )
-        {
-            ChangeState<EnemyDieState>();
-        }
-
     }
 
     public R ChangeState<R>() where R : State<EnemyController>

--- a/Assets/Scripts/Enemy/State/EnemyDieState.cs
+++ b/Assets/Scripts/Enemy/State/EnemyDieState.cs
@@ -23,10 +23,6 @@ public class EnemyDieState : State<EnemyController>
 
         _enemyController._isDie = true;
         _enemyController._anim.SetTrigger("Die");
-
-        
-        
-        Debug.Log("DeadState");
         
     }
 

--- a/Assets/Scripts/Enemy/State/EnemyDieState.cs
+++ b/Assets/Scripts/Enemy/State/EnemyDieState.cs
@@ -20,16 +20,17 @@ public class EnemyDieState : State<EnemyController>
         _agent = _enemyController._agent;
         _agent.isStopped = true;
 
-        //if (_enemyController._isDie) return;
-        
-        _enemyController._anim.SetTrigger("Die");
-        _enemyController._isDie = true;
 
+        _enemyController._isDie = true;
+        _enemyController._anim.SetTrigger("Die");
+
+        
+        
+        Debug.Log("DeadState");
         
     }
 
     public override void Update(float deltaTime)
     {
-        Debug.Log("DeadState");
     }
 }

--- a/Assets/Scripts/Enemy/State/EnemyHitState.cs
+++ b/Assets/Scripts/Enemy/State/EnemyHitState.cs
@@ -22,11 +22,15 @@ public class EnemyHitState : State<EnemyController>
         _agent.isStopped = true;
 
 
-        _enemyController._anim.SetTrigger("Hit");                       // anim
+
 
         // 체력 감소 및 적용
         _enemyController.HP -= _enemyController._eventDamage;
         _enemyController._enemyUI._hpBarSlider.value = _enemyController.HP;
+
+        if (_enemyController.HP <= 0) return;
+
+        _enemyController._anim.SetTrigger("Hit");                       // anim
     }
 
     public override void Update(float deltaTime)

--- a/Assets/Scripts/Enemy/State/EnemyIdleState.cs
+++ b/Assets/Scripts/Enemy/State/EnemyIdleState.cs
@@ -14,11 +14,6 @@ public class EnemyIdleState : State<EnemyController>
 
         _enemyController = _context.GetComponent<EnemyController>();
 
-        if(_enemyController.HP <= 0)
-        {
-            _enemyController.ChangeState<EnemyDieState>();
-        }
-
         _enemyController._anim.SetBool("Walk",false);
         _enemyController._anim.SetBool("WalkToPlayer", false);
 

--- a/Assets/Scripts/Player/Player.cs
+++ b/Assets/Scripts/Player/Player.cs
@@ -208,6 +208,9 @@ public class Player : Entity
         _recoveryValue = playerData.RecoveryValue; // 회복 시간당 회복량
 
         #endregion
+
+        _playerHit = GetComponent<PlayerHit>();
+        _playerDie = GetComponent<PlayerDie>();
     }
 
     public override void Hit(float damage, GameObject attacker)


### PR DESCRIPTION
## 개요✍️
- 몬스터의 죽음 처리 

## 작업사항🛠️
- 몬스터의 dieState를 호출하는 여러 호출들 제거. 

## 변경 로직🕹️
- hit anim trigger를 호출하는 순서를  낮춰서 die가 더 우선으로 오게 함 


