### PR TITLE
Hotfix-CameraBlock

### DIFF
--- a/Assets/Scenes/TrainScene/MineScene.unity
+++ b/Assets/Scenes/TrainScene/MineScene.unity
@@ -1300,6 +1300,36 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4f71dc2421c736c488099334cadb3a8a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &1586892074
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1586892070}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e501d18bb52cf8c40b1853ca4904654f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_CollideAgainst:
+    serializedVersion: 2
+    m_Bits: 1
+  m_IgnoreTag: 
+  m_TransparentLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_MinimumDistanceFromTarget: 0.1
+  m_AvoidObstacles: 1
+  m_DistanceLimit: 0
+  m_MinimumOcclusionTime: 0
+  m_CameraRadius: 0.1
+  m_Strategy: 1
+  m_MaximumEffort: 4
+  m_SmoothingTime: 0
+  m_Damping: 0
+  m_DampingWhenOccluded: 0
+  m_OptimalTargetDistance: 0
 --- !u!1 &1667440065
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
## 개요✍️
- 카메라가 벽을 통과하여 투시하는 상황 발생

## 작업사항🛠️
- 카메라의 통과를 방지하기 위해 QuaterViewCam의 Cinemachine Collider를 추가하여 방지함.

수정 전

https://github.com/Train-Adventure-Endless-Challenge/Train-Adventure/assets/82390527/8c65a272-bd8c-4a97-9a37-6a92ebfed932



수정 후

https://github.com/Train-Adventure-Endless-Challenge/Train-Adventure/assets/82390527/f3ecfe99-5773-4a19-bb0e-c75834f09cce

