### PR TITLE
:art: ㅣ enemy 공격 로직 수정

### DIFF
--- a/Assets/Animations/Enemy/Melee/Enemy_Melee@Attack.fbx.meta
+++ b/Assets/Animations/Enemy/Melee/Enemy_Melee@Attack.fbx.meta
@@ -57,7 +57,7 @@ ModelImporter:
       bodyMask: 01000000010000000100000001000000010000000100000001000000010000000100000001000000010000000100000001000000
       curves: []
       events:
-      - time: 0.502907
+      - time: 1
         functionName: CheckHitEvent
         data: 
         objectReferenceParameter: {instanceID: 0}

--- a/Assets/Prefabs/Enemy/TempEnemy_Melee.prefab
+++ b/Assets/Prefabs/Enemy/TempEnemy_Melee.prefab
@@ -81,6 +81,64 @@ Rigidbody:
   m_Interpolate: 0
   m_Constraints: 0
   m_CollisionDetection: 0
+--- !u!1 &2831945785208348811
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6195476234122715035}
+  - component: {fileID: 1485441566979215035}
+  - component: {fileID: 4246539694235512782}
+  m_Layer: 9
+  m_Name: Attack
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6195476234122715035
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2831945785208348811}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 462754116407091878}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!135 &1485441566979215035
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2831945785208348811}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 1.5
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!114 &4246539694235512782
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2831945785208348811}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fcca28cd41c056e4f87b09a1ac5ec636, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &2295046494633368942
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -459,6 +517,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 8108ce0871a5bef40b50a4caa6a35149, type: 3}
+--- !u!4 &462754116407091878 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1852576806548013000, guid: 8108ce0871a5bef40b50a4caa6a35149,
+    type: 3}
+  m_PrefabInstance: {fileID: 2295046494633368942}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1376075573183225919 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 919132149155446097, guid: 8108ce0871a5bef40b50a4caa6a35149,

--- a/Assets/Scripts/Enemy/EnemyAttack_Melee.cs
+++ b/Assets/Scripts/Enemy/EnemyAttack_Melee.cs
@@ -1,0 +1,24 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class EnemyAttack_Melee : MonoBehaviour
+{
+    EnemyController _enemyController;
+
+    private void Awake()
+    {
+        _enemyController = GetComponentInParent<EnemyController>(); 
+    }
+
+    private void OnTriggerEnter(Collider other)
+    {
+        if (!_enemyController._isCurrentAttackCor) return;
+
+        if(other.gameObject.CompareTag("Player"))
+        {
+            Player player = other.gameObject.GetComponent<Player>();
+            player.Hit(_enemyController.Damage, _enemyController.gameObject);
+        }
+    }
+}

--- a/Assets/Scripts/Enemy/EnemyAttack_Melee.cs
+++ b/Assets/Scripts/Enemy/EnemyAttack_Melee.cs
@@ -13,7 +13,7 @@ public class EnemyAttack_Melee : MonoBehaviour
 
     private void OnTriggerEnter(Collider other)
     {
-        if (!_enemyController._isCurrentAttackCor) return;
+        if (!_enemyController._isCurrentAttackCor) return;          // 현재 공격 상태가 아니라면 return
 
         if(other.gameObject.CompareTag("Player"))
         {

--- a/Assets/Scripts/Enemy/EnemyAttack_Melee.cs.meta
+++ b/Assets/Scripts/Enemy/EnemyAttack_Melee.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fcca28cd41c056e4f87b09a1ac5ec636
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Enemy/Type/EnemyController_Melee.cs
+++ b/Assets/Scripts/Enemy/Type/EnemyController_Melee.cs
@@ -53,8 +53,7 @@ public class EnemyController_Melee : EnemyController
 
         yield return new WaitForSeconds(AttackSpeed);
 
-        _agent.isStopped = false;
-        _isCurrentAttackCor = false;
+
 
     }
 
@@ -63,13 +62,8 @@ public class EnemyController_Melee : EnemyController
     /// </summary>
     public void CheckHitEvent()
     {
-
-        // 실제 공격 체크
-        if (_enemyFieldOfView._isVisiblePlayer && Vector3.Distance(transform.position, _player.transform.position) < AttackRange + _agent.stoppingDistance)
-        {
-            Player player = _player.GetComponent<Player>();     //  추후 싱글톤으로 찾는다면 로직 수정
-            player.Hit(Damage,gameObject);
-        }
+        _agent.isStopped = false;
+        _isCurrentAttackCor = false;
 
         ChangeState<EnemyIdleState>();
 


### PR DESCRIPTION
## 개요✍️
- 근거리 몬스터의 공격 모션을 변경하였습니다.

## 작업사항🛠️
- 기존 거리로 체크하는 공격 방식이 animation 클립에 맞지 않아 로직을 수정하였습니다. 

## 변경 로직🕹️
- 몬스터의 왼손에 콜라이더를 설정하여 공격 모션이 될때만 trigger 체크로 player의 hit 함수를 호출하게 변경되었습니다

