### PR TITLE
Feature hit screen

### DIFF
--- a/Assets/Scenes/GameCycle.meta
+++ b/Assets/Scenes/GameCycle.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 189a705a0f6c42545906c4c0f874897f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/GameCycle.unity
+++ b/Assets/Scenes/GameCycle.unity
@@ -663,7 +663,7 @@ MonoBehaviour:
   priority: 0
   blendDistance: 0
   weight: 1
-  sharedProfile: {fileID: 11400000, guid: c36dafbd5c395c2448d5606a875f3271, type: 2}
+  sharedProfile: {fileID: 11400000, guid: 6c937184ef8517848b7154f7bbbd4a4b, type: 2}
 --- !u!4 &563713817
 Transform:
   m_ObjectHideFlags: 0
@@ -1862,7 +1862,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1091245265}
-  m_LocalRotation: {x: 0.3743562, y: -0.34985992, z: 0.15506344, w: 0.8446365}
+  m_LocalRotation: {x: 0.37435618, y: -0.34985992, z: 0.15506345, w: 0.8446365}
   m_LocalPosition: {x: 6.41, y: 13, z: -6.41}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
@@ -2156,7 +2156,7 @@ PrefabInstance:
     - target: {fileID: 635215942287709944, guid: a2c350fdf1c82474d95e3a9d14b65590,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.3743562
+      value: 0.37435618
       objectReference: {fileID: 0}
     - target: {fileID: 635215942287709944, guid: a2c350fdf1c82474d95e3a9d14b65590,
         type: 3}
@@ -2166,7 +2166,7 @@ PrefabInstance:
     - target: {fileID: 635215942287709944, guid: a2c350fdf1c82474d95e3a9d14b65590,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0.15506344
+      value: 0.15506345
       objectReference: {fileID: 0}
     - target: {fileID: 635215942287709944, guid: a2c350fdf1c82474d95e3a9d14b65590,
         type: 3}

--- a/Assets/Scenes/GameCycle.unity
+++ b/Assets/Scenes/GameCycle.unity
@@ -617,6 +617,68 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &563713814
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 563713817}
+  - component: {fileID: 563713816}
+  - component: {fileID: 563713815}
+  m_Layer: 0
+  m_Name: Hit Volume
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &563713815
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 563713814}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9a27a28337d65f540ada279ad59612e6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &563713816
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 563713814}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 172515602e62fb746b5d573b38a5fe58, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IsGlobal: 1
+  priority: 0
+  blendDistance: 0
+  weight: 1
+  sharedProfile: {fileID: 11400000, guid: c36dafbd5c395c2448d5606a875f3271, type: 2}
+--- !u!4 &563713817
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 563713814}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1066500651}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &722364089
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1544,6 +1606,11 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 6401699004113738585, guid: a19a6135a5352bc4286384ebace07097,
+        type: 3}
+      propertyPath: _hitVolume
+      value: 
+      objectReference: {fileID: 563713815}
     - target: {fileID: 6401699005772241260, guid: a19a6135a5352bc4286384ebace07097,
         type: 3}
       propertyPath: m_Name
@@ -1658,6 +1725,7 @@ Transform:
   m_Children:
   - {fileID: 986810277}
   - {fileID: 2120364709}
+  - {fileID: 563713817}
   m_Father: {fileID: 0}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -1794,7 +1862,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1091245265}
-  m_LocalRotation: {x: 0.37435618, y: -0.34985992, z: 0.15506345, w: 0.8446365}
+  m_LocalRotation: {x: 0.3743562, y: -0.34985992, z: 0.15506344, w: 0.8446365}
   m_LocalPosition: {x: 6.41, y: 13, z: -6.41}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
@@ -1825,7 +1893,7 @@ MonoBehaviour:
     m_Bits: 1
   m_VolumeTrigger: {fileID: 0}
   m_VolumeFrameworkUpdateModeOption: 2
-  m_RenderPostProcessing: 0
+  m_RenderPostProcessing: 1
   m_Antialiasing: 0
   m_AntialiasingQuality: 2
   m_StopNaN: 0
@@ -2088,7 +2156,7 @@ PrefabInstance:
     - target: {fileID: 635215942287709944, guid: a2c350fdf1c82474d95e3a9d14b65590,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.37435618
+      value: 0.3743562
       objectReference: {fileID: 0}
     - target: {fileID: 635215942287709944, guid: a2c350fdf1c82474d95e3a9d14b65590,
         type: 3}
@@ -2098,7 +2166,7 @@ PrefabInstance:
     - target: {fileID: 635215942287709944, guid: a2c350fdf1c82474d95e3a9d14b65590,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0.15506345
+      value: 0.15506344
       objectReference: {fileID: 0}
     - target: {fileID: 635215942287709944, guid: a2c350fdf1c82474d95e3a9d14b65590,
         type: 3}

--- a/Assets/Scenes/GameCycle/Hit Volume Profile.asset
+++ b/Assets/Scenes/GameCycle/Hit Volume Profile.asset
@@ -1,0 +1,44 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &-1484974864638269947
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 899c54efeace73346a0a16faa3afe726, type: 3}
+  m_Name: Vignette
+  m_EditorClassIdentifier: 
+  active: 1
+  color:
+    m_OverrideState: 1
+    m_Value: {r: 1, g: 0, b: 0, a: 1}
+  center:
+    m_OverrideState: 0
+    m_Value: {x: 0.5, y: 0.5}
+  intensity:
+    m_OverrideState: 1
+    m_Value: 0.3
+  smoothness:
+    m_OverrideState: 1
+    m_Value: 0.01
+  rounded:
+    m_OverrideState: 0
+    m_Value: 0
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d7fd9488000d3734a9e00ee676215985, type: 3}
+  m_Name: Hit Volume Profile
+  m_EditorClassIdentifier: 
+  components:
+  - {fileID: -1484974864638269947}

--- a/Assets/Scenes/GameCycle/Hit Volume Profile.asset.meta
+++ b/Assets/Scenes/GameCycle/Hit Volume Profile.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6c937184ef8517848b7154f7bbbd4a4b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/TempPlayerScene/Hit Volume.asset
+++ b/Assets/Scenes/TempPlayerScene/Hit Volume.asset
@@ -21,10 +21,10 @@ MonoBehaviour:
     m_Value: {x: 0.5, y: 0.5}
   intensity:
     m_OverrideState: 1
-    m_Value: 0.4
+    m_Value: 0.3
   smoothness:
     m_OverrideState: 1
-    m_Value: 0.2
+    m_Value: 0.01
   rounded:
     m_OverrideState: 0
     m_Value: 0

--- a/Assets/Scripts/Player/Player.cs
+++ b/Assets/Scripts/Player/Player.cs
@@ -16,6 +16,7 @@ public class Player : Entity
 
     #region Data
 
+    [Header("Data")]
     /// <summary>
     /// 스크립터블 오브젝트로 저장 되어 있는 플레이어 데이터 원본 값
     /// </summary>
@@ -25,13 +26,17 @@ public class Player : Entity
 
     #region Class
 
-    private PlayerHit _playerHit; // 플레이어 히트 담당 클래스
-    private PlayerDie _playerDie; // 플레이어 죽음 담당 클래스
-
+    [Header("State")]
     /// <summary>
     /// 플레이어의 상태를 저장하는 Enum 값
     /// </summary>
     public PlayerState playerState;
+
+    [Header("Volume")]
+    [SerializeField] private HitVolume _hitVolume; // 피격 볼륨
+
+    private PlayerHit _playerHit; // 플레이어 히트 담당 클래스
+    private PlayerDie _playerDie; // 플레이어 죽음 담당 클래스
 
     #endregion
 
@@ -40,7 +45,7 @@ public class Player : Entity
     private float _speed; // 속도
     private int _defense; // 방어력
     private int _stamina; // 스태미나
-    public int _maxStamina;
+    [HideInInspector] public int _maxStamina; // 최대 스태미나
 
     #endregion
 
@@ -166,7 +171,6 @@ public class Player : Entity
     {
         Init(); // 초기화 실행
         base.Start();
-
     }
 
     #endregion
@@ -248,12 +252,14 @@ public class Player : Entity
 
         _playerHit.Hit(damage);
         IngameUIController.Instance.UpdateHp(_hp, MaxHp);
+        _hitVolume.ChangeVolume(1 - _hp / MaxHp);
     }
 
     public void Heal(float healAmount)
     {
         _hp += healAmount;
         IngameUIController.Instance.UpdateHp(_hp, MaxHp);
+        _hitVolume.ChangeVolume(1 - _hp / MaxHp);
     }
 
     public override void Die()

--- a/Assets/Scripts/PostProcessing/HitVolume.cs
+++ b/Assets/Scripts/PostProcessing/HitVolume.cs
@@ -9,10 +9,6 @@ public class HitVolume : MonoBehaviour
 {
     #region Variable
 
-    [Header("Variable")]
-    [SerializeField] private Player _player;
-    [SerializeField] private PlayerData _playerData;
-
     private Volume _volume;
     private Vignette _vignette;
 
@@ -29,9 +25,9 @@ public class HitVolume : MonoBehaviour
 
     #endregion
 
-    private void OnEnable()
+    public void ChangeVolume(float hp)
     {
-        _vignette.smoothness.value = 1 - _player.Hp / _playerData.Hp; // 플레이어 체력량에 따라 굵어짐
+        _vignette.smoothness.value = hp; // 플레이어 체력량에 따라 굵어짐
     }
 
     /// <summary>
@@ -41,8 +37,6 @@ public class HitVolume : MonoBehaviour
     {
         _volume = GetComponent<Volume>();
         _volume.profile.TryGet(out _vignette);
-
-        _player = PlayerManager.Instance.gameObject.GetComponent<Player>();
     }
 
     #endregion

--- a/Assets/Scripts/PostProcessing/HitVolume.cs
+++ b/Assets/Scripts/PostProcessing/HitVolume.cs
@@ -25,6 +25,10 @@ public class HitVolume : MonoBehaviour
 
     #endregion
 
+    /// <summary>
+    /// 볼륨값을 변경하는 함수
+    /// </summary>
+    /// <param name="hp"></param>
     public void ChangeVolume(float hp)
     {
         _vignette.smoothness.value = hp; // 플레이어 체력량에 따라 굵어짐


### PR DESCRIPTION
## 개요✍️
- 피격 화면 수정

## 작업사항🛠️
- 피격 화면이 활성화되지 않던 버그 해결
- 비교 화면
![image](https://github.com/Train-Adventure-Endless-Challenge/Train-Adventure/assets/82390527/6073961c-c767-48fc-aca7-fcc6604d72a0)
평소
![image](https://github.com/Train-Adventure-Endless-Challenge/Train-Adventure/assets/82390527/1320af57-cc94-44d1-baab-1e62577b8485)
피격 최대 값
- 영상

https://github.com/Train-Adventure-Endless-Challenge/Train-Adventure/assets/82390527/603711f2-77b6-42c2-950a-957d45c16d82

## 변경 로직🕹️
- 원래 Hit Volume을 비/활성화로 플레이어 체력량에 따라 수정했지만, Hit시 값을 변경하는 것으로 수정