### PR TITLE
:bug: | 단검 흔들림 없는 버그 수정

### DIFF
--- a/Assets/Scripts/Item/Weapon/Dagger.cs
+++ b/Assets/Scripts/Item/Weapon/Dagger.cs
@@ -71,6 +71,8 @@ public class Dagger : Weapon
             _detectionLists.Add(collision.gameObject);
             Destroy(Instantiate(_hittingFeelingEffect, collision.contacts[0].thisCollider.transform.position, collision.transform.rotation), 2);
             collision.gameObject.GetComponent<Entity>().Hit(_damage, _playerTransform.gameObject);
+            Shake();
+
         }
     }
 


### PR DESCRIPTION
## 개요✍️
- 단검 흔들림 버그 픽스

## 작업사항🛠️
- 단검의 OnCollisionEnter함수에 Shake함수가 빠져있어 추가해줌.
