### PR TITLE
:sparkles: | Wall Collider Layer 추가

### DIFF
--- a/Assets/Prefabs/Train/ModelTrain/BossTrain_People.prefab
+++ b/Assets/Prefabs/Train/ModelTrain/BossTrain_People.prefab
@@ -3472,6 +3472,11 @@ PrefabInstance:
       propertyPath: m_Name
       value: train_people
       objectReference: {fileID: 0}
+    - target: {fileID: 5148817236446094103, guid: 65addb80ec0e1264fb983050b118d917,
+        type: 3}
+      propertyPath: m_Layer
+      value: 14
+      objectReference: {fileID: 0}
     - target: {fileID: 6383459688497237020, guid: 65addb80ec0e1264fb983050b118d917,
         type: 3}
       propertyPath: m_IsActive

--- a/Assets/Prefabs/Train/ModelTrain/DoorCol.prefab
+++ b/Assets/Prefabs/Train/ModelTrain/DoorCol.prefab
@@ -10,7 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 7305181686847497013}
   - component: {fileID: 8215082500013297016}
-  m_Layer: 0
+  m_Layer: 14
   m_Name: DoorCol
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -24,7 +24,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 804556489713620112}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: -0.08, y: 0.76, z: -19.26}
   m_LocalScale: {x: 0.89887, y: 1, z: 1}
   m_ConstrainProportionsScale: 0

--- a/Assets/Prefabs/Train/ModelTrain/FrontCol.prefab
+++ b/Assets/Prefabs/Train/ModelTrain/FrontCol.prefab
@@ -10,7 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 9030450417611884587}
   - component: {fileID: 6069411380604491115}
-  m_Layer: 0
+  m_Layer: 14
   m_Name: FrontCol
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -54,7 +54,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 7649961062866594877}
-  m_Layer: 0
+  m_Layer: 14
   m_Name: FrontCol
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -88,7 +88,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4320702627813427235}
   - component: {fileID: 4346895169655939315}
-  m_Layer: 0
+  m_Layer: 14
   m_Name: FrontCol1
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/Assets/Prefabs/Train/ModelTrain/StartTrain_People.prefab
+++ b/Assets/Prefabs/Train/ModelTrain/StartTrain_People.prefab
@@ -3529,6 +3529,11 @@ PrefabInstance:
       propertyPath: m_Name
       value: train_people
       objectReference: {fileID: 0}
+    - target: {fileID: 5148817236446094103, guid: 65addb80ec0e1264fb983050b118d917,
+        type: 3}
+      propertyPath: m_Layer
+      value: 14
+      objectReference: {fileID: 0}
     - target: {fileID: 6383459688497237020, guid: 65addb80ec0e1264fb983050b118d917,
         type: 3}
       propertyPath: m_IsActive

--- a/Assets/Prefabs/Train/ModelTrain/StoreTrain_People .prefab
+++ b/Assets/Prefabs/Train/ModelTrain/StoreTrain_People .prefab
@@ -2309,6 +2309,11 @@ PrefabInstance:
       propertyPath: m_StaticEditorFlags
       value: 8
       objectReference: {fileID: 0}
+    - target: {fileID: -1857309847194865932, guid: ee16de5adb8b434488d3e9aef055f2f6,
+        type: 3}
+      propertyPath: m_Layer
+      value: 14
+      objectReference: {fileID: 0}
     - target: {fileID: -1538112130698044685, guid: ee16de5adb8b434488d3e9aef055f2f6,
         type: 3}
       propertyPath: m_LocalScale.x

--- a/Assets/Prefabs/Train/ModelTrain/Wall.prefab
+++ b/Assets/Prefabs/Train/ModelTrain/Wall.prefab
@@ -10,7 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 700008766256005339}
   - component: {fileID: 318772999577066969}
-  m_Layer: 0
+  m_Layer: 14
   m_Name: Wall
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/Assets/Scripts/Player/PlayerAttack.cs
+++ b/Assets/Scripts/Player/PlayerAttack.cs
@@ -129,6 +129,8 @@ public class PlayerAttack : MonoBehaviour
         // 특정 layer만 raycast제외하기 (RightWall)
         if (Physics.Raycast(ray, out hitResult, 100, _layerMask))
         {
+            Debug.Log(hitResult.transform.gameObject.name);
+            Debug.Log(hitResult.transform.gameObject.name);
             Vector3 mouseDir = new Vector3(hitResult.point.x, transform.position.y, hitResult.point.z) - transform.position;
             transform.forward = mouseDir;
         }

--- a/Assets/Scripts/Player/PlayerAttack.cs
+++ b/Assets/Scripts/Player/PlayerAttack.cs
@@ -129,8 +129,6 @@ public class PlayerAttack : MonoBehaviour
         // 특정 layer만 raycast제외하기 (RightWall)
         if (Physics.Raycast(ray, out hitResult, 100, _layerMask))
         {
-            Debug.Log(hitResult.transform.gameObject.name);
-            Debug.Log(hitResult.transform.gameObject.name);
             Vector3 mouseDir = new Vector3(hitResult.point.x, transform.position.y, hitResult.point.z) - transform.position;
             transform.forward = mouseDir;
         }


### PR DESCRIPTION
## 개요✍️
- 플레이어 공격 방향 결정 ray가 벽에 막힘

## 작업사항🛠️
- 오른쪽 벽 Collider Object에 RightWall Layer 추가



