### PR TITLE
근접 몬스터 콜라이더 비활성화 되지 않는 버그 수정

### DIFF
--- a/Assets/Animations/Enemy/Melee/Enemy_Melee@Attack.fbx.meta
+++ b/Assets/Animations/Enemy/Melee/Enemy_Melee@Attack.fbx.meta
@@ -64,7 +64,7 @@ ModelImporter:
         floatParameter: 0
         intParameter: 0
         messageOptions: 0
-      - time: 0.86976326
+      - time: 0.79459983
         functionName: CheckHitEndEffect
         data: 
         objectReferenceParameter: {instanceID: 0}

--- a/Assets/Prefabs/Enemy/TempEnemy_Melee.prefab
+++ b/Assets/Prefabs/Enemy/TempEnemy_Melee.prefab
@@ -136,7 +136,7 @@ CapsuleCollider:
   m_GameObject: {fileID: 2831945785208348811}
   m_Material: {fileID: 0}
   m_IsTrigger: 1
-  m_Enabled: 1
+  m_Enabled: 0
   m_Radius: 1.91
   m_Height: 8.78
   m_Direction: 1
@@ -895,6 +895,7 @@ MonoBehaviour:
   _eventDamage: 0
   _isAttackCheck: 0
   _attackTrail: {fileID: 0}
+  _attackCollider: {fileID: 5032977086311672275}
 --- !u!114 &2295046494633368939
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Enemy/Controller/EnemyController_Melee.cs
+++ b/Assets/Scripts/Enemy/Controller/EnemyController_Melee.cs
@@ -10,6 +10,7 @@ public class EnemyController_Melee : EnemyController
     public bool _isAttackCheck = false;             // animation event clip으로 실행할 공격 체크 함수
 
     public TrailRenderer _attackTrail;
+    public Collider _attackCollider;
     protected override void Start()
     {
         base.Start();
@@ -69,12 +70,14 @@ public class EnemyController_Melee : EnemyController
     {
         _attackTrail.enabled = true;
         _isAttackCheck = true;
+        _attackCollider.enabled = true;
     }
 
     public void CheckHitEndEffect()
     {
         _attackTrail.enabled = false;
         _isAttackCheck = false;
+        _attackCollider.enabled = false;
     }
 
     /// <summary>


### PR DESCRIPTION
## 개요✍️
- 근접 몬스터 콜라이더 비활성화 되지 않는 버그 수정

## 작업사항🛠️
- Collider관련 로직이 아예없는것을 확인하고 추가
- 근접몹 콜라이더 종료 이벤트 조금 앞당김


https://github.com/Train-Adventure-Endless-Challenge/Train-Adventure/assets/82389915/ed9d562b-a58b-4f6e-aecd-c4f225db1c61

아무리 비벼도 공격할 때만 피격당합니다.

