### PR TITLE
Fix-ShakingGaugeExceeded

### DIFF
--- a/Assets/Scripts/Managers/Shake/ShakeManager.cs
+++ b/Assets/Scripts/Managers/Shake/ShakeManager.cs
@@ -52,7 +52,6 @@ public class ShakeManager : SceneSingleton<ShakeManager>
         if (_shake._impulseDefinition.m_AmplitudeGain > _maxValue)
         {
             _shake._impulseDefinition.m_AmplitudeGain = _maxValue;
-            return;
         }
 
         IngameUIController.Instance.UpdateShakeUI(ShakeAmount); // UI 업데이트


### PR DESCRIPTION
## 개요✍️
- 최대 흔들림 초과 오류 해결

## 작업사항🛠️
- 흔들림이 최대 값을 넘어갈 시 UI 초기화가 안되는 의도치 않은 버그 수정
- 변경 후

https://github.com/Train-Adventure-Endless-Challenge/Train-Adventure/assets/82390527/c933c299-05c1-4305-b461-d463f47188d8
