### PR TITLE
몬스터 공격 중 hit시 collider가 남는 버그 수정

### DIFF
--- a/Assets/Scripts/Enemy/Controller/EnemyController_Melee.cs
+++ b/Assets/Scripts/Enemy/Controller/EnemyController_Melee.cs
@@ -102,4 +102,10 @@ public class EnemyController_Melee : EnemyController
     {
         StartCoroutine(AttackMeleeCor());
     }
+
+    public override void Hit(float damage, GameObject attacker)
+    {
+        base.Hit(damage, attacker);
+        CheckHitEndEffect();
+    }
 }


### PR DESCRIPTION
## 개요✍️
- 몬스터 공격 중 hit시 collider가 남는 버그 수정

## 작업사항🛠️
- 몬스터의 hit시 collider를 제거하는 코드 추가