### PR TITLE
Enemy Speed

### DIFF
--- a/Assets/Animations/Enemy/Melee/Enemy_Melee.controller
+++ b/Assets/Animations/Enemy/Melee/Enemy_Melee.controller
@@ -607,7 +607,7 @@ AnimatorState:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: Walking
-  m_Speed: 1.5
+  m_Speed: 1.2
   m_CycleOffset: 0
   m_Transitions:
   - {fileID: -3715120896574095144}
@@ -636,7 +636,7 @@ AnimatorState:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: Walking_Target
-  m_Speed: 2
+  m_Speed: 1.5
   m_CycleOffset: 0
   m_Transitions:
   - {fileID: -8040986307167964321}

--- a/Assets/Animations/Enemy/Melee/Enemy_Melee.controller
+++ b/Assets/Animations/Enemy/Melee/Enemy_Melee.controller
@@ -353,7 +353,7 @@ AnimatorState:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: Attack
-  m_Speed: 1
+  m_Speed: 0.8
   m_CycleOffset: 0
   m_Transitions:
   - {fileID: 2111189045049497946}
@@ -387,43 +387,43 @@ AnimatorController:
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: WalkToPlayer
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: Attack
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: Hit
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: Discovery
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: DieTrue
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: AttackCancel
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   m_AnimatorLayers:
   - serializedVersion: 5
     m_Name: Base Layer

--- a/Assets/Animations/Enemy/Scientist/Enemy_Scientist.controller
+++ b/Assets/Animations/Enemy/Scientist/Enemy_Scientist.controller
@@ -574,49 +574,49 @@ AnimatorController:
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: WalkToPlayer
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: Attack
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: Hit
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: Shooting
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: AttackInt
     m_Type: 3
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: Discovery
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: DieTrue
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   m_AnimatorLayers:
   - serializedVersion: 5
     m_Name: Base Layer

--- a/Assets/Data/Enemy/Temp_Enemy_Bomb.asset
+++ b/Assets/Data/Enemy/Temp_Enemy_Bomb.asset
@@ -15,7 +15,7 @@ MonoBehaviour:
   _name: 
   _hp: 1
   _damage: 3
-  _moveSpeed: 5
+  _moveSpeed: 2
   _attackSpeed: 3
   _attackRange: 0
   _enemyType: 3

--- a/Assets/Data/Enemy/Temp_Enemy_Boss_Cave.asset
+++ b/Assets/Data/Enemy/Temp_Enemy_Boss_Cave.asset
@@ -15,7 +15,7 @@ MonoBehaviour:
   _name: 
   _hp: 700
   _damage: 10
-  _moveSpeed: 10
+  _moveSpeed: 5
   _attackSpeed: 5
   _attackRange: 10
   _enemyType: 4

--- a/Assets/Data/Enemy/Temp_Enemy_Melee.asset
+++ b/Assets/Data/Enemy/Temp_Enemy_Melee.asset
@@ -15,7 +15,7 @@ MonoBehaviour:
   _name: 
   _hp: 40
   _damage: 5
-  _moveSpeed: 5
+  _moveSpeed: 1
   _attackSpeed: 5
   _attackRange: 3
   _enemyType: 1

--- a/Assets/Data/Enemy/Temp_Enemy_Melee.asset
+++ b/Assets/Data/Enemy/Temp_Enemy_Melee.asset
@@ -15,7 +15,7 @@ MonoBehaviour:
   _name: 
   _hp: 40
   _damage: 5
-  _moveSpeed: 1
+  _moveSpeed: 2
   _attackSpeed: 5
   _attackRange: 3
   _enemyType: 1

--- a/Assets/Data/Enemy/Temp_Enemy_Range.asset
+++ b/Assets/Data/Enemy/Temp_Enemy_Range.asset
@@ -15,7 +15,7 @@ MonoBehaviour:
   _name: 
   _hp: 20
   _damage: 5
-  _moveSpeed: 1
+  _moveSpeed: 2
   _attackSpeed: 5
   _attackRange: 10
   _enemyType: 0

--- a/Assets/Data/Enemy/Temp_Enemy_Range.asset
+++ b/Assets/Data/Enemy/Temp_Enemy_Range.asset
@@ -15,7 +15,7 @@ MonoBehaviour:
   _name: 
   _hp: 20
   _damage: 5
-  _moveSpeed: 5
+  _moveSpeed: 1
   _attackSpeed: 5
   _attackRange: 10
   _enemyType: 0

--- a/Assets/Data/Enemy/Temp_Enemy_Scientist.asset
+++ b/Assets/Data/Enemy/Temp_Enemy_Scientist.asset
@@ -15,7 +15,7 @@ MonoBehaviour:
   _name: 
   _hp: 100
   _damage: 5
-  _moveSpeed: 1
+  _moveSpeed: 2
   _attackSpeed: 5
   _attackRange: 5
   _enemyType: 2

--- a/Assets/Data/Enemy/Temp_Enemy_Scientist.asset
+++ b/Assets/Data/Enemy/Temp_Enemy_Scientist.asset
@@ -15,7 +15,7 @@ MonoBehaviour:
   _name: 
   _hp: 100
   _damage: 5
-  _moveSpeed: 5
+  _moveSpeed: 1
   _attackSpeed: 5
   _attackRange: 5
   _enemyType: 2

--- a/Assets/Scripts/Enemy/EnemyController.cs
+++ b/Assets/Scripts/Enemy/EnemyController.cs
@@ -101,6 +101,7 @@ public abstract class EnemyController : Entity
         _enemyDieSound = _enemyData._enemyDieSound;
 
         _agent.stoppingDistance = AttackRange;
+        _agent.speed = MoveSpeed;
 
         _dieEvent += GearDrop;
 


### PR DESCRIPTION
## 개요✍️
- 몬스터의 속도 감소 (공격, 이동)

## 작업사항🛠️
- MoveSpeed => 5 -> 2
- Enemy_melee 의 Attack Animation Speed 1 -> 0.8로 감소
-  animation Attack Walking clip은 2 -> 1.5로 감소

## 변경 로직🕹️
- 기존 enemy Data가 실제 Speed 로 적용되지 않고 있어서 적용되게 변경하였다. 


https://github.com/Train-Adventure-Endless-Challenge/Train-Adventure/assets/81548078/4cbc3a03-3f35-4bd8-a7c1-2432ef969ec3



