### PR TITLE
Hotfix bomb enemy

### DIFF
--- a/Assets/Prefabs/Enemy/TempEnemy_Bomb.prefab
+++ b/Assets/Prefabs/Enemy/TempEnemy_Bomb.prefab
@@ -407,6 +407,10 @@ MonoBehaviour:
   _eventDamage: 0
   _bombEffect: {fileID: 8592499858754565221, guid: e450b5eb9f9ce8c4c98c07918ad5ac11,
     type: 3}
+  targetLayer:
+    serializedVersion: 2
+    m_Bits: 256
+  _detectionRange: 2
 --- !u!195 &185151429469142990
 NavMeshAgent:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Enemy/Controller/EnemyController_Bomb.cs
+++ b/Assets/Scripts/Enemy/Controller/EnemyController_Bomb.cs
@@ -66,7 +66,7 @@ public class EnemyController_Bomb : EnemyController
     /// <returns></returns>
     private IEnumerator OnCollisionPlayer()
     {
-        while (Vector2.Distance(transform.position, _player.transform.position) > _detectionRange) // 플레이어를 감지할 때 까지 대기
+        while (Vector2.Distance(transform.localPosition, _player.transform.position) > _detectionRange) // 플레이어를 감지할 때 까지 대기
         {
             yield return new WaitForEndOfFrame();
         }


### PR DESCRIPTION
## 개요✍️
- 폭탄이 2개 있을 경우 한 폭탄이 먹통이 되는 버그 수정

## 작업사항🛠️
- 누락 되었던 레이어 설정을 추가하였습니다. (targetLayer -> Player 설정)
- 거리 비교문의 조건을 변경하였습니다. (transform.position -> transform.localPosition)

- 변경 후

https://github.com/Train-Adventure-Endless-Challenge/Train-Adventure/assets/82390527/cfa71315-373e-4709-8aeb-4e03de1689d6