### PR TITLE
:art: | 대검 Item Model 누락 추가

### DIFF
--- a/Assets/Resources/Prefabs/Item/GreatSwrod.prefab
+++ b/Assets/Resources/Prefabs/Item/GreatSwrod.prefab
@@ -85,7 +85,7 @@ MonoBehaviour:
   _itemType: 0
   _itemDestroyEffect: {fileID: 823794951709449306, guid: 09493efb518a384428bb7500e8dcd0e9,
     type: 3}
-  _itemModel: {fileID: 0}
+  _itemModel: {fileID: 919132147706024984}
   _weaponCollider: {fileID: 5510357528307337339}
   currentCoolTime: 0
   isSkillExist: 1
@@ -266,6 +266,12 @@ PrefabInstance:
 --- !u!4 &543450651961101986 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: bfd0741139e2a7e41b7ebde372b2995b,
+    type: 3}
+  m_PrefabInstance: {fileID: 1772480841}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &919132147706024984 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 919132149155446097, guid: bfd0741139e2a7e41b7ebde372b2995b,
     type: 3}
   m_PrefabInstance: {fileID: 1772480841}
   m_PrefabAsset: {fileID: 0}


### PR DESCRIPTION
## 개요✍️
- 대검 Item Model 누락 추가

## 작업사항🛠️
- 변수 Item Model의 값이 누락 되어있어, 자식 모델을 넣는 것으로 해결하였습니다.

![image](https://github.com/Train-Adventure-Endless-Challenge/Train-Adventure/assets/82390527/d82f9cd7-3015-4d79-8e28-f7886ca28df7)
